### PR TITLE
Set fixed Chrome profile path to mitigate storage overrun

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Configuration is done using environment variables:
 * `GRAFANA_PASSWORD`: The password to log in to the Grafana dashboard.
 * `WINDOW_WIDTH`: The width of the browser window for capturing screenshots. Default is '1280'.
 * `WINDOW_HEIGHT`: The height of the browser window for capturing screenshots. Default is '1024'.
+* `CHROME_PROFILE`: Path to a Chrome profile directory to use for the browser. Default is `/app/chrome-profile`.
 
 These environment variables can be set in your system's environment variable settings, or in the script that calls your Python script. For local development, you can also set these variables in a `.env` file and use a tool like `python-dotenv` to load them.
 

--- a/grafanascreenshots.py
+++ b/grafanascreenshots.py
@@ -94,6 +94,13 @@ def get_dashboard_url():
 
     return new_url
 
+def setup_chrome_profile_path():
+    path = os.getenv('CHROME_PROFILE', '/app/chrome-profile')
+    try:
+        os.makedirs(path, exist_ok=True)
+        return path
+    except OSError as e:
+        raise OSError(f"Failed to create CHROME_PROFILE directory: {e}")
 
 # Register signal handler for SIGINT and SIGTERM
 signal.signal(signal.SIGINT, signal_handler)
@@ -118,6 +125,9 @@ chrome_options.add_argument("--headless")
 chrome_options.add_argument("--no-sandbox")
 chrome_options.add_argument("--kiosk")
 
+# Set the user profile directory for Chrome
+chrome_profile = setup_chrome_profile_path()
+chrome_options.add_argument(f"--user-data-dir={chrome_profile}")
 
 capture_screenshot()
 # Capture a screenshot every 30 seconds


### PR DESCRIPTION
This pull request sets Chrome up for a fixed profile path to keep it from re-creating new profiles, eventually filling the available storage on the host.

### Documentation Update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17): Added `CHROME_PROFILE` environment variable description, which specifies the path to a Chrome profile directory.

### Code Enhancements:
* [`grafanascreenshots.py`](diffhunk://#diff-d632aa9902d692ba12d562e63709f84fd7db31f9e7b99a7c1d50f136ac1a4333R97-R104): Added `setup_chrome_profile_path` function to create the Chrome profile directory if it does not exist and handle any errors that occur during its creation.
* [`grafanascreenshots.py`](diffhunk://#diff-d632aa9902d692ba12d562e63709f84fd7db31f9e7b99a7c1d50f136ac1a4333R129-R131): Updated the script to set the user profile directory for Chrome using the new `CHROME_PROFILE` environment variable.