### PR TITLE
Downgrade changelog generator action to version 2.3 for improved output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-          # Needed for correct Maven version detection
           fetch-depth: 0
 
       - name: "Generate release changelog"
         id: generate-release-changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.4
+        # Version 2.4 is available, but creates scrambled output
+        uses: janheinrichmerker/action-github-changelog-generator@v2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           onlyLastTag: "true" # set to false if no tags exist (buggy with only one tag)


### PR DESCRIPTION
This pull request downgrades the release changelog generator to 2.3 to fix an issue with scrambled output in 2.4. Also profile user name for the action repository has  been changed.

Workflow improvements:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L18-R23): Changed the `generate-release-changelog` step to use `janheinrichmerker/action-github-changelog-generator@v2.3` instead of `heinrichreimer/github-changelog-generator-action@v2.4` to avoid issues with scrambled output.