### PR TITLE
Fix that programm would not end

### DIFF
--- a/grafanascreenshots.py
+++ b/grafanascreenshots.py
@@ -137,4 +137,7 @@ schedule.every(30).seconds.do(capture_screenshot)
 while schedule.get_jobs():
     schedule.run_pending()
     time.sleep(1)
+
+client.disconnect()
+
 print("All jobs have been completed. Exiting...")

--- a/grafanascreenshots.py
+++ b/grafanascreenshots.py
@@ -133,7 +133,8 @@ capture_screenshot()
 # Capture a screenshot every 30 seconds
 schedule.every(30).seconds.do(capture_screenshot)
 
-
-while True:
+# Schedule is cleared when signal is received
+while schedule.get_jobs():
     schedule.run_pending()
     time.sleep(1)
+print("All jobs have been completed. Exiting...")


### PR DESCRIPTION
This pull request includes a change to the `grafanascreenshots.py` file to improve the handling of scheduled jobs. Specifically, it modifies the loop that runs scheduled jobs to check for remaining jobs and print a message once all jobs have been completed, so that the loop finally comes to an end.

Changes to job scheduling:

* [`grafanascreenshots.py`](diffhunk://#diff-d632aa9902d692ba12d562e63709f84fd7db31f9e7b99a7c1d50f136ac1a4333L137-R140): Modified the loop to check for remaining scheduled jobs using `schedule.get_jobs()` and added a print statement to indicate when all jobs have been completed.