### PR TITLE
Fix kiosk mode

### DIFF
--- a/grafanascreenshots.py
+++ b/grafanascreenshots.py
@@ -78,9 +78,7 @@ def get_dashboard_url():
     # Parse the URL into components
     url_parts = urlparse(url)
 
-    # Append the "autofitpanels" query parameter
     query = parse_qs(url_parts.query)
-    query.update({"kiosk": ["tv"]})
 
     # Construct the new URL
     new_url_parts = ParseResult(
@@ -93,7 +91,8 @@ def get_dashboard_url():
     )
     new_url = urlunparse(new_url_parts)
 
-    new_url = str(new_url) + "&autofitpanels"
+    # Append the "autofitpanels" and "kiosk" query parameter
+    new_url = str(new_url) + "&autofitpanels&kiosk"
 
     return new_url
 

--- a/grafanascreenshots.py
+++ b/grafanascreenshots.py
@@ -111,7 +111,10 @@ signal.signal(signal.SIGTERM, signal_handler)
 
 broker_url = check_env_var('MQTT_BROKER_URL')
 mqtt_topic = check_env_var('MQTT_TOPIC')
+
 dashboard_url = get_dashboard_url()
+print(f"Dashboard URL: {dashboard_url}")
+
 username = check_env_var('GRAFANA_USERNAME')
 password = check_env_var('GRAFANA_PASSWORD')
 


### PR DESCRIPTION
This pull request includes changes to the `grafanascreenshots.py` file, focusing on modifying the URL construction logic and adding debugging output. The most important changes include updating the query parameters in the `get_dashboard_url` function and adding a print statement for debugging purposes.

This seems to be a regression with newer Grafana versions, as the kiosk mode has worked before.

Changes to URL construction:

* [`grafanascreenshots.py`](diffhunk://#diff-d632aa9902d692ba12d562e63709f84fd7db31f9e7b99a7c1d50f136ac1a4333L96-R95): Updated the `get_dashboard_url` function to append both "autofitpanels" and "kiosk" query parameters.

Debugging improvements:

* [`grafanascreenshots.py`](diffhunk://#diff-d632aa9902d692ba12d562e63709f84fd7db31f9e7b99a7c1d50f136ac1a4333R113-R116): Added a print statement to output the constructed dashboard URL for debugging purposes in the `setup_chrome_profile_path` function.